### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,4 @@
+eda:
+  type: kicad
+  pcb: board/hydromisc.kicad_pcb
+bom: board/fab/hydromisc-bill-of-materials-revB.csv


### PR DESCRIPTION
Hey, I saw your project on the "Show HN" and thought it's a good candidate for putting up a [Kitspace.org](https://kitspace.org) page. All that's required is a small manifest file to point Kitspace at the right files. 

Here is [a preview](http://try-hydromisc.preview.kitspace.org/boards/github.com/kitspace-forks/hydromisc/). The Gerbers on Kitpsace are plotted from the KiCad file because we don't support unzipping zip files from repositories yet. (I  also noticed there are some readme processing issues on the Kitspace side with the code fences. We'll have to look at that.)

If you are happy to add the page, just merge this. The page will keep updating with this repo (every 3 hours or so). 